### PR TITLE
Changes after server renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,4 +82,4 @@ More complicated search queries can b constructed, by combining several AND/OR c
 ['cf1intmon', 'cf1intyr', ...
 ```
 
-For more complicated search queries, you may find the interactive [Advanced Search](http://metadata.fragilefamilies.princeton.edu/search) page on the project website useful.
+For more complicated search queries, you may find the interactive [Advanced Search](http://metadata.ffcws.princeton.edu/search) page on the project website useful.

--- a/ff/__init__.py
+++ b/ff/__init__.py
@@ -39,9 +39,9 @@ import json
 import urllib
 import requests
 
-__version__ = '1.1.1'
+__version__ = '2.0.0'
 name = "ffmetadata-py"
-BASE_URL = 'http://api.metadata.fragilefamilies.princeton.edu'
+BASE_URL = 'https://api.metadata.ffcws.princeton.edu'
 
 
 def select(var_name, attr_name=None):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="ffmetadata-py",
-    version="1.1.1",
+    version="2.0.0",
     author="Alex Kindel, Vineet Bansal",
     author_email="akindel@princeton.edu, vineetb@princeton.edu",
     description="Python wrapper for The Fragile Families Metadata API",


### PR DESCRIPTION
The API endpoint `http://api.metadata.fragilefamilies.princeton.edu` is no longer supported, but has changed to `https://api.metadata.ffcws.princeton.edu`.